### PR TITLE
Help is printed when no arguments are given to djboss

### DIFF
--- a/src/djboss/cli.py
+++ b/src/djboss/cli.py
@@ -84,6 +84,10 @@ def main():
         PARSER.set_defaults(log_level='DEBUG')
     else:
         PARSER.set_defaults(log_level='WARN')
+    
+    if len(sys.argv) == 1:
+        PARSER.print_help()
+        sys.exit(1)
 
     args = PARSER.parse_args()
     logging.root.setLevel(getattr(logging, args.log_level))


### PR DESCRIPTION
I found myself spending a lot of time typing "djboss jsldkfsd" to force it to give me command names when I forgot them. This would make it a bit easier..
